### PR TITLE
Remove -U option

### DIFF
--- a/lib/sm.js
+++ b/lib/sm.js
@@ -17,7 +17,7 @@ function SM(opts) {
     opts = opts || {};
 
     // Create the child process.
-    this._proc = cp.spawn(opts.shell || "js", ["-i", "-U"]);
+    this._proc = cp.spawn(opts.shell || "js", ["-i"]);
     this._proc.stdin.setEncoding("utf8");
     this._proc.stderr.setEncoding("utf8");
     this._proc.stderr.on("data", this._data.bind(this));


### PR DESCRIPTION
This option must have been removed from Spidermonkey shell some time ago and now causes it to exit with the error message.

```
Error: Invalid short option: -U
```

[MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Introduction_to_the_JavaScript_shell) doesn't know about it either.
