### PR TITLE
Don't swallow errors: add error event

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Each callback takes an error object signifying that SpiderMonkey threw an except
 
   * `"message"` : received a response from the SpiderMonkey shell
   * `"exit"` : the SpiderMonkey shell has exited
+  * `"error"` : the SpiderMonkey shell has errored (e.g. failed to spawn)
 
 ## License
 

--- a/lib/sm.js
+++ b/lib/sm.js
@@ -113,9 +113,10 @@ SM.prototype._data = function _data(str) {
     buf.push(str);
 };
 
-SM.prototype._exit = function _exit() {
+SM.prototype._exit = function _exit(err) {
     this._alive = false;
-    this.emit("exit");
+    var event = err instanceof Error ? 'error' : 'exit';
+    this.emit.apply(this, [event].concat([].slice.call(arguments)));
 };
 
 SM.prototype._send = function _send(src, request, callback) {


### PR DESCRIPTION
This patch introduces `error` event which is called whenever Spidermonkey shell child process fails for some reason.

Silently ignoring error events can make it difficult to debug in some cases.
